### PR TITLE
Popup reform

### DIFF
--- a/client/lib/popup.js
+++ b/client/lib/popup.js
@@ -1,0 +1,150 @@
+Popup = {
+    /// This function returns a callback that can be used in an event map:
+    ///
+    ///   Template.tplName.events({
+    ///      'click .elementClass': Popup.open("popupName")
+    ///   });
+    ///
+    /// The popup inherit the data context of its parent.
+    open: function(name) {
+        var self = this;
+        var popupName = name + "Popup";
+
+        return function(evt, tpl) {
+            var $element = tpl.$(evt.currentTarget);
+            evt.originalEvent.clickInPopup = true
+            self._render({
+                __isPopup: true,
+                popupName: popupName,
+                hasPopupParent: self._hasPopupParent(),
+                title: self._getTitle(popupName),
+                offset: self._getOffset($element),
+                dataContext: this
+            });
+            evt.preventDefault();
+        }
+    },
+
+    /// This function returns a callback that can be used in an event map:
+    ///
+    ///   Template.tplName.events({
+    ///      'click .elementClass': Popup.afterConfirm("popupName", function() {
+    ///          // What to do after the user has confirmed the action
+    ///      })
+    ///   });
+    afterConfirm: function(name, action) {
+        var self = this;
+
+        return function(evt, tpl) {
+            var context = this;
+            context.__afterConfirmAction = action;
+            self.open(name).call(context, evt, tpl);
+        }
+    },
+
+    // In case the popup was opened from a parent popup we can get back to it
+    // with this `Popup.back()` function.
+    back: function() {
+        if (this._stack.length >= 2) {
+            this._stack.pop();
+            this._render(this._stack.pop());
+        }
+    },
+
+    // Close the current opened popup.
+    close: function() {
+        if (this.current) {
+            this._remove();
+            this.current = null;
+            this._stack = [];
+        }
+    },
+
+    // The template we use for the every popup
+    template: Template.popup,
+
+    // We only want to display one popup at a time and we keep the view object
+    // in this `Popup._current` variable. If there is no popup currently opened
+    // the value is `null`.
+    _current: null,
+
+    // It's possible to open a sub-popup B from a popup A. In that case we keep
+    // the data of popup A so we can return back to it.
+    _stack: [],
+
+    // We automatically calculate the popup offset from the element size and
+    // the window dimensions.
+    // XXX It should be reactive!
+    _getOffset: function($element) {
+        if (this._hasPopupParent())
+            return this._stack[this._stack.length - 1].offset;
+
+        var offset = $element.offset();
+        var popupWidth = 300 + 15;
+        return {
+            left: Math.min(offset.left, $(window).width() - popupWidth),
+            top: offset.top + $element.outerHeight()
+        };
+    },
+
+    // We get the title from the translation files.
+    // XXX It should be reactive!
+    _getTitle: function(popupName) {
+        var translationKey = popupName + "-title";
+        // XXX There is no public API to check if there is an available
+        // translation for a given key. So we try to translate the key and if
+        // the translation output equals the key input we deduce that no
+        // translation was available and returns `false`. There is a (small)
+        // risk a false positives.
+        var title = TAPi18n.__(translationKey);
+        return title !== translationKey ? title : false;
+    },
+
+    // We use the blaze API to determine if the current popup has been opened
+    // from a parent popup. The number we give to the `Template.parentData` has
+    // been determined experimentally and is susceptible to change if you modify
+    // the `Popup.template`
+    _hasPopupParent: function() {
+        var tryParentData = Template.parentData(3);
+        return !! (tryParentData && tryParentData.__isPopup);
+    },
+
+    // Add the popup to the DOM. If a popup is already opened it will be closed
+    _render: function(data) {
+        this._remove();
+        this._stack.push(data);
+        this.current = Blaze.renderWithData(this.template, data, document.body);
+    },
+
+    // Remove the popup from the DOM
+    _remove: function() {
+        if (this.current) {
+            Blaze.remove(this.current)
+        }
+    }
+};
+
+Popup.template.events({
+    'click': function(event) {
+        event.originalEvent.clickInPopup = true;
+    },
+    'click .js-back-view': function() {
+        Popup.back();
+    },
+    'click .js-close-popover': function() {
+        Popup.close();
+    },
+    'click .js-confirm': function() {
+        Popup.close();
+        this.__afterConfirmAction.call(this);
+    }
+});
+
+// We automatically close a potential opened popup on any click on the document.
+// To avoid closing it unexpectedly we modify the bubbled event in case the
+// click event happen in the popup or in a button that open a popup.
+$(document).on('click', function (event) {
+    if (! (event.originalEvent && event.originalEvent.clickInPopup)) {
+        Popup.close();
+    }
+});

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -1,38 +1,3 @@
-var Offsets = {
-    headerUser: function(offset) {
-        return { left: (offset.left - 118), top: (offset.top + 40) }
-    },
-    list: function(offset) {
-        return { left: (offset.left + 230), top: (offset.top + 25) }
-    },
-    boardName: function(offset) {
-        return { left: (offset.left), top: (offset.top + 35) }
-    },
-    boardPermission: function(offset) {
-        return this.boardName(offset);
-    },
-    boardRemove: function(offset) {
-        return { left: (offset.left - 61), top: (offset.top - 8) }
-    },
-    membersAdd: function(offset) {
-        return { left: (offset.left - 61), top: (offset.top + 35) }
-    },
-    member: function(offset) {
-        var width = $(window).width();
-        return { left: (width - 310), top: (offset.top + 35) }
-    },
-    user: function(offset) {
-        return { left: (offset.left), top: (offset.top + 20) }
-    },
-    removeMember: function(offset) {
-        var width = $(window).width();
-        return { left: (width - 310), top: (offset.top - 103) }
-    },
-    button: function(offset) {
-        return { left: offset.left, top: (offset.top + 40) }
-    }
-};
-
 Utils = {
     error: function(err) {
         Session.set("error", (err && err.message || false));
@@ -78,13 +43,8 @@ Utils = {
         widgets.height(wrapper.height());
         boardActions.height(wrapper.height() - 215);
         pop.find('.content').css('max-height', widgets.height() / 2);
-
-        // resize and default pop offset
-        if (pop[0]) {
-            var popOffset = Utils.Pop.getOffset($('.openPop').get());
-            pop.css({ top: popOffset.top, left: popOffset.left });
-        }
     },
+
     // scroll
     Scroll: function(selector) {
         var $el = $(selector);
@@ -98,32 +58,6 @@ Utils = {
                 $el.animate({ scrollLeft: (add ? (l + px) : px) });
             }
         };
-    },
-
-    // Pop
-    Pop: {
-        getOffset: function($el) {
-            var $this = $($el),
-                offset = Offsets[$this.attr('popOffset')]($this.offset());
-            return offset;
-        },
-        open: function(template, label, $el, data) {
-            var offset = this.getOffset($el);
-            Session.set('pop', {
-                template: template,
-                label: label,
-                left: offset.left,
-                top: offset.top,
-                data: data || {}
-            });
-
-            // openPop
-            $($el).addClass('openPop');
-        },
-        close: function() {
-            Session.set('pop', false);
-            $('.openPop').removeClass('openPop');
-        }
     },
 
     Warning: {

--- a/client/styles/main.styl
+++ b/client/styles/main.styl
@@ -1684,6 +1684,7 @@ dd {
     top: -9999px;
     width: 300px;
     z-index: 99999;
+    margin-top: 5px;
 
     hr {
         margin: 8px 0;
@@ -1753,15 +1754,14 @@ dd {
         }
 
         .back-btn {
-            display: none;
             padding: 10px 4px 10px 10px;
             position: absolute;
             top: 0;
             left: 0;
-        }
 
-        .back-btn:hover .icon-sm {
-            color: #686868;
+            &:hover .icon-sm {
+                color: #686868;
+            }
         }
 
         .close-btn {
@@ -1769,10 +1769,10 @@ dd {
             position: absolute;
             top: 0;
             right: 0;
-        }
 
-        .close-btn:hover .icon-sm {
-            color: #686868;
+            &:hover .icon-sm {
+                color: #686868;
+            }
         }
     }
 

--- a/client/views/activities/templates.html
+++ b/client/views/activities/templates.html
@@ -8,7 +8,7 @@
                     </span>
                 </div>
                 <div class="phenom-desc">
-                    {{ > memberName user=user offset='member' }}
+                    {{ > memberName user=user }}
 
                     {{# if isTrue activityType 'createBoard' }}
                         {{_ 'activity-create-board'}}
@@ -50,18 +50,18 @@
                     {{ /if }}
 
                     {{# if isTrue activityType 'addBoardMember' }}
-                        added {{ > memberName user=member offset='member' }} to this board.
+                        added {{ > memberName user=member }} to this board.
                     {{ /if }}
 
                     {{# if isTrue activityType 'removeBoardMember' }}
-                        excluded {{ > memberName user=member offset='member' }} from this board.
+                        excluded {{ > memberName user=member }} from this board.
                     {{ /if }}
 
                     {{# if isTrue activityType 'joinMember' }}
                         {{# if isTrue currentUser._id member._id }}
                             joined <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>.
                         {{ else }}
-                            added {{ > memberName user=member offset='member' }} to <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>.
+                            added {{ > memberName user=member }} to <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>.
                         {{/if}}
                     {{ /if }}
 
@@ -69,7 +69,7 @@
                         {{# if isTrue currentUser._id member._id }}
                             unjoined <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>.
                         {{ else }}
-                            removed {{ > memberName user=member offset='member' }} from <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>.
+                            removed {{ > memberName user=member }} from <a href="{{ card.absoluteUrl }}" class="action-card">{{ card.title }}</a>.
                         {{/if}}
                     {{ /if }}
 
@@ -103,7 +103,7 @@
                     </div>
                     <form>
                         <div class="phenom-desc">
-                            {{ > memberName user=user offset='user' }}
+                            {{ > memberName user=user }}
                             <div class="action-comment markeddown">
                                 <div class="current-comment">
                                   {{#viewer}}{{ text }}{{/viewer}}
@@ -132,7 +132,7 @@
                     <div class="creator member js-show-mem-menu">
                         <span class="member-initials" title="{{ user.profile.name }} ({{ user.username }})">{{ firstChar user.profile.name }}</span>
                     </div>
-                    {{ > memberName user=user offset='user' }}
+                    {{ > memberName user=user }}
                     {{# if isTrue activityType 'createCard' }}
                         added this card to {{ list.title }}.
                     {{ /if }}
@@ -140,14 +140,14 @@
                         {{# if isTrue currentUser._id member._id }}
                             joined this card.
                         {{ else }}
-                            added this card to {{ > memberName user=member offset='user' }}.
+                            added this card to {{ > memberName user=member }}.
                         {{/if}}
                     {{/if}}
                     {{# if isTrue activityType 'unjoinMember' }}
                         {{# if isTrue currentUser._id member._id }}
                             unjoined this card.
                         {{ else }}
-                            removed this card from {{ > memberName user=member offset='user' }}.
+                            removed this card from {{ > memberName user=member }}.
                         {{/if}}
                     {{ /if }}
                     {{# if isTrue activityType 'archivedCard' }}

--- a/client/views/boards/events.js
+++ b/client/views/boards/events.js
@@ -16,17 +16,13 @@ Template.boards.events({
 
 Template.board.events({
     'click .js-star-board': function(event, t) {
-        toggleBoardStar(Boards.findOne()._id);
+        toggleBoardStar(this._id);
     },
-    'click .js-rename-board:not(.no-edit)': function(event, t) {
-        Utils.Pop.open('changeBoardTitlePop', 'Rename Board', event.currentTarget, Boards.findOne());
-    },
-    'click #permission-level:not(.no-edit)': function(event, t) {
-        Utils.Pop.open('changePermissionBoardPop', 'Change Visibility', event.currentTarget, Boards.findOne());
-    }
+    'click .js-rename-board:not(.no-edit)': Popup.open('boardChangeTitle'),
+    'click #permission-level:not(.no-edit)': Popup.open('boardChangePermission')
 });
 
-Template.createBoardPop.events({
+Template.createBoardPopup.events({
     'submit #CreateBoardForm': function(event, t) {
         var title = t.$('#boardNewTitle');
 
@@ -42,36 +38,31 @@ Template.createBoardPop.events({
     }
 });
 
-Template.changeBoardTitlePop.events({
+Template.boardChangeTitlePopup.events({
     'submit #ChangeBoardTitleForm': function(event, t) {
-        var title = t.$('.js-board-name');
-        if ($.trim(title.val())) {
+        var title = t.$('.js-board-name').val().trim();
+        if (title) {
             Boards.update(this._id, {
                 $set: {
-                    title: title.val()
+                    title: title
                 }
             });
-
-            // pop close
-            Utils.Pop.close();
+            Popup.close();
         }
         event.preventDefault();
     }
 });
 
-Template.changePermissionBoardPop.events({
+Template.boardChangePermissionPopup.events({
     'click .js-select': function(event, t) {
         var $this = $(event.currentTarget),
             permission = $this.attr('name');
 
-        // update permission
         Boards.update(this._id, {
             $set: {
                 permission: permission
             }
         });
-
-        // pop close
-        Utils.Pop.close();
+        Popup.close();
     }
 });

--- a/client/views/boards/helpers.js
+++ b/client/views/boards/helpers.js
@@ -21,9 +21,6 @@ Template.boards.helpers({
 });
 
 Template.board.helpers({
-    board: function() {
-        return Boards.findOne({});
-    },
     isStarred: function() {
         var boardId = Boards.findOne()._id,
             user = Meteor.user();
@@ -31,7 +28,7 @@ Template.board.helpers({
     }
 });
 
-Template.changePermissionBoardPop.helpers({
+Template.boardChangePermissionPopup.helpers({
     check: function(perm) {
         return this.permission == perm;
     }

--- a/client/views/boards/rendered.js
+++ b/client/views/boards/rendered.js
@@ -21,5 +21,5 @@ var jsAutofocus = function() {
     this.find('.js-autofocus').focus();
 };
 
-Template.changeBoardTitlePop.rendered = jsAutofocus;
-Template.createBoardPop.rendered = jsAutofocus;
+Template.boardChangeTitlePopup.rendered = jsAutofocus;
+Template.createBoardPopup.rendered = jsAutofocus;

--- a/client/views/boards/routers.js
+++ b/client/views/boards/routers.js
@@ -23,5 +23,8 @@ Router.route('/boards/:boardId/:slug', {
             // Board page list, cards members vs
             Meteor.subscribe('board', params.boardId, params.slug)
         ]
+    },
+    data: function() {
+        return Boards.findOne(this.params.boardId);
     }
 });

--- a/client/views/boards/templates.html
+++ b/client/views/boards/templates.html
@@ -40,33 +40,33 @@
 </template>
 
 <template name="board">
-    {{# if board }}
+    {{# if this }}
         <div class="board-wrapper {{# unless openWidgets }}disabled-all-widgets{{/ unless }}">
             <div class="board-header clearfix js-board-header">
-                <a href="#" class="board-header-btn board-header-btn-name js-rename-board {{# unless currentUser.isBoardAdmin }}no-edit{{/ unless}}" popoffset='boardName' title="Rename the board.">
-                    <span class="board-header-btn-text"> {{ board.title }} </span>
+                <a href="#" class="board-header-btn board-header-btn-name js-rename-board {{# unless currentUser.isBoardAdmin }}no-edit{{/ unless}}" title="Rename the board.">
+                    <span class="board-header-btn-text"> {{ title }} </span>
                 </a>
                 <div class="board-header-btns left">
                     {{# unless isSandstorm }}
                         <a href="#" class="board-header-btn js-star-board {{#if isStarred }}board-header-btn-enabled{{/ if }}" title="Click to {{# if isStarred }}unstar{{ else }}star{{/ if }} this board. Starred boards show up at the top of your boards list.">
                             <span class="board-header-btn-icon icon-sm icon-star"></span>
                         </a>
-                        <a href="#" class="board-header-btn perms-btn js-change-vis {{# unless currentUser.isBoardAdmin }}no-edit{{/ unless}}" id="permission-level" popoffset='boardPermission'>
-                            <span class="board-header-btn-icon icon-sm icon-{{ toLowerCase board.permission }}"></span>
-                            <span class="board-header-btn-text">{{ board.permission }}</span>
+                        <a href="#" class="board-header-btn perms-btn js-change-vis {{# unless currentUser.isBoardAdmin }}no-edit{{/ unless}}" id="permission-level">
+                            <span class="board-header-btn-icon icon-sm icon-{{ toLowerCase permission }}"></span>
+                            <span class="board-header-btn-text">{{ permission }}</span>
                         </a>
                     {{/ unless }}
                 </div>
             </div>
-            {{ > boardWidgets board=board }}
-            {{ > lists board=board }}
+            {{ > boardWidgets board=this }}
+            {{ > lists board=this }}
         </div>
     {{ else }}
         {{ > message label='board-not-found' color='white'}}
     {{/if}}
 </template>
 
-<template name="createBoardPop">
+<template name="createBoardPopup">
     <div class="content clearfix fancy-scrollbar js-tab-parent">
         <form id="CreateBoardForm">
             <label for="boardNewTitle">{{_ 'title'}}</label>
@@ -79,7 +79,7 @@
     </div>
 </template>
 
-<template name="changeBoardTitlePop">
+<template name="boardChangeTitlePopup">
     <form id="ChangeBoardTitleForm">
         <label>{{_ 'name'}}</label>
         <input type="text" class="js-board-name js-autofocus" value="{{ title }}" autofocus>
@@ -87,7 +87,7 @@
     </form>
 </template>
 
-<template name="changePermissionBoardPop">
+<template name="boardChangePermissionPopup">
     <ul class="pop-over-list">
         <li>
             <a class="js-select light-hover" href="#" name="Private">

--- a/client/views/cards/helpers.js
+++ b/client/views/cards/helpers.js
@@ -1,8 +1,8 @@
 Template.addCardForm.helpers({});
 
-Template.cardMembersPop.helpers({
+Template.cardMembersPopup.helpers({
     isCardMember: function() {
-        var cardId = Template.parentData().cardId;
+        var cardId = Template.parentData().card._id;
         var cardMembers = Cards.findOne(cardId).members || [];
         return _.contains(cardMembers, this.userId);
     },
@@ -11,13 +11,13 @@ Template.cardMembersPop.helpers({
     }
 });
 
-Template.cardLabelsPop.helpers({
+Template.cardLabelsPopup.helpers({
     isLabelSelected: function(cardId) {
         return _.contains(Cards.findOne(cardId).labelIds, this._id);
     }
 });
 
-Template.editLabelPop.helpers({
+Template.editLabelPopup.helpers({
     labels: function() {
         var colors = ['green', 'yellow', 'orange', 'red', 'purple', 'blue',
         'sky', 'lime', 'pink', 'black'];

--- a/client/views/cards/rendered.js
+++ b/client/views/cards/rendered.js
@@ -54,10 +54,10 @@ Template.cards.rendered = function() {
     });
 };
 
-Template.editLabelPop.rendered = function() {
+Template.editLabelPopup.rendered = function() {
     this.find('.js-autofocus').focus();
 };
 
-Template.cardMorePop.rendered = function() {
+Template.cardMorePopup.rendered = function() {
     this.find('.js-autoselect').select();
 };

--- a/client/views/cards/routers.js
+++ b/client/views/cards/routers.js
@@ -1,12 +1,6 @@
 Router.route('/boards/:boardId/:slug/:cardId', {
     name: 'Card',
-    template: 'board',
     bodyClass: 'page-index chrome chrome-39 mac extra-large-window body-webkit-scrollbars body-board-view bgBoard window-up',
-    yieldRegions: {
-        'cardModal': {
-            to: 'modal'
-        }
-    },
     waitOn: function() {
         var params = this.params;
         return [
@@ -18,15 +12,18 @@ Router.route('/boards/:boardId/:slug/:cardId', {
             Meteor.subscribe('board', params.boardId, params.slug)
         ]
     },
-    data: function() {
+    action: function() {
         var params = this.params;
-        return {
-            card: function() {
-                return Cards.findOne(params.cardId);
-            },
-            board: function() {
+        this.render('board', {
+            data: function() {
                 return Boards.findOne(params.boardId);
             }
-        }
+        });
+        this.render('cardModal', {
+            to: 'modal',
+            data: function() {
+                return Cards.findOne(params.cardId);
+            }
+        });
     }
 });

--- a/client/views/cards/templates.html
+++ b/client/views/cards/templates.html
@@ -38,10 +38,10 @@
 </template>
 
 <template name="cardModal">
-    {{ > modal template='cardDetailWindow' card=card board=board }}
+    {{ > modal template='cardDetailWindow' card=this board=this.board }}
 </template>
 
-<template name="cardMemberPop">
+<template name="cardMemberPopup">
     <div class="board-member-menu">
         <div class="mini-profile-info">
             <div class="member-large">
@@ -62,11 +62,11 @@
     </div>
 </template>
 
-<template name="cardMembersPop">
+<template name="cardMembersPopup">
     <div>
         {{! <input class="js-search-mem js-autofocus" placeholder="Search members…" type="text"> }}
         <ul class="pop-over-member-list checkable js-mem-list">
-            {{# each members }}
+            {{# each card.board.members }}
                 <li class="item {{#if isCardMember}}active{{/if}} js-member-item">
                     <a href="#" class="name js-select-member">
                         {{> avatar memberId=userId }}
@@ -82,29 +82,29 @@
     </div>
 </template>
 
-<template name="cardMorePop">
+<template name="cardMorePopup">
     <p class="quiet bottom">
         <span class="clearfix">
             <span>{{_ 'link-card'}}</span>
-            <span class="icon-sm icon-{{ toLowerCase board.permission }}"></span>
-            <input class="js-url js-autoselect inline-input" type="text" readonly="readonly" value="{{ rootUrl }}">
+            <span class="icon-sm icon-{{ toLowerCase card.board.permission }}"></span>
+            <input class="js-url js-autoselect inline-input" type="text" readonly="readonly" value="{{ card.rootUrl }}">
         </span>
         {{_ 'added'}} <span class="date" title="{{ card.createdAt }}">{{ moment card.createdAt 'LLL' }}</span> -
-        <a class="js-delete" href="#" title="{{_ 'card-delete-notice'}}" popoffset="button">{{_ 'delete'}}</a>
+        <a class="js-delete" href="#" title="{{_ 'card-delete-notice'}}">{{_ 'delete'}}</a>
     </p>
 </template>
 
-<template name="cardLabelsPop">
+<template name="cardLabelsPopup">
     <div>
         {{! <input id="labelSearch" name="search" class="js-autofocus js-label-search" placeholder="Search labels…" value="" type="text"> }}
         <ul class="edit-labels-pop-over js-labels-list">
-            {{# each labels }}
+            {{# each card.board.labels }}
                 <li>
                     <a href="#" class="card-label-edit-button icon-sm icon-edit js-edit-label"></a>
-                    <span class="card-label card-label-selectable card-label-{{color}} js-select-label {{# if isLabelSelected ../cardId }}active{{/ if }}">
+                    <span class="card-label card-label-selectable card-label-{{color}} js-select-label {{# if isLabelSelected ../card._id }}active{{/ if }}">
                         {{name}}
                         {{# if currentUser.isBoardAdmin }}
-                            <span class="card-label-selectable-icon icon-sm icon-check light" popoffset='button'></span>
+                            <span class="card-label-selectable-icon icon-sm icon-check light"></span>
                         {{/ if }}
                     </span>
                 </li>
@@ -113,7 +113,7 @@
     </div>
 </template>
 
-<template name="editLabelPop">
+<template name="editLabelPopup">
     <form class="edit-label">
         <div class="colors clearfix">
             <label for="labelName">{{_ 'name'}}</label>
@@ -130,7 +130,7 @@
     </form>
 </template>
 
-<template name="deleteCardPop">
+<template name="cardDeletePopup">
     <p>{{_ "card-delete-pop"}}</p>
     <input type="submit" class="js-confirm negate full" value="{{_ 'delete'}}">
 </template>
@@ -193,7 +193,7 @@
                                 {{# each card.members }}
                                     {{> avatar memberId=this }}
                                 {{/ each }}
-                                <a class="card-detail-item-add-button dark-hover js-details-edit-members" popoffset="button">
+                                <a class="card-detail-item-add-button dark-hover js-details-edit-members">
                                     <span class="icon-sm icon-add"></span>
                                 </a>
                             </div>
@@ -206,7 +206,7 @@
                                 {{# each card.labels }}
                                     <span class="card-label card-label-{{color}}" title="{{name}}">{{ name }}</span>
                                 {{/ each }}
-                                <a class="card-detail-item-add-button dark-hover js-details-edit-labels" popoffset="button">
+                                <a class="card-detail-item-add-button dark-hover js-details-edit-labels">
                                     <span class="icon-sm icon-add"></span>
                                 </a>
                             </div>
@@ -279,10 +279,10 @@
         <div class="window-module clearfix">
             <h3>{{_ 'add'}}</h3>
             <div class="clearfix">
-                <a href="#" class="button-link js-change-card-members" title="{{_ 'members-title'}}" popoffset="button">
+                <a href="#" class="button-link js-change-card-members" title="{{_ 'members-title'}}">
                     <span class="icon-sm icon-member"></span> {{_ 'members'}}
                 </a>
-                <a href="#" class="button-link js-edit-labels" title="{{_ 'labels-title'}}" popoffset="button">
+                <a href="#" class="button-link js-edit-labels" title="{{_ 'labels-title'}}">
                     <span class="icon-sm icon-label"></span> {{_ 'labels'}}
                 </a>
             </div>
@@ -295,7 +295,7 @@
                     <a href="#" class="button-link js-unarchive-card" title="{{_ 'send-to-board-title'}}">
                         <span class="icon-sm icon-reopen"></span> {{_ 'send-to-board'}}
                     </a>
-                    <a href="#" class="button-link negate js-delete-card" title="{{_ 'delete-title'}}" popoffset="button">
+                    <a href="#" class="button-link negate js-delete-card" title="{{_ 'delete-title'}}">
                         <span class="icon-sm icon-remove"></span> {{_ 'delete'}}
                     </a>
                 {{ else }}
@@ -307,7 +307,7 @@
         </div>
         <div class="window-module clearfix">
             <p class="quiet bottom">
-                <a href="#" class="quiet-button js-more-menu" title="{{_ 'share-and-more-title'}}" popoffset="button">{{_ 'share-and-more'}}</a>
+                <a href="#" class="quiet-button js-more-menu" title="{{_ 'share-and-more-title'}}">{{_ 'share-and-more'}}</a>
             </p>
         </div>
     </div>

--- a/client/views/lists/events.js
+++ b/client/views/lists/events.js
@@ -17,14 +17,7 @@ Template.lists.events({
         // stop click hash
         event.preventDefault();
     },
-    'click .js-open-list-menu': function(event, t) {
-        var $this = $(event.currentTarget),
-            list = $this.parents('.list');
-
-        // open pop
-        Utils.Pop.open('listActionPop', 'List Actions', list[0], this);
-        event.preventDefault();
-    },
+    'click .js-open-list-menu': Popup.open('listAction'),
     'click .hide-on-edit': function(event, t) {
         var $this = $(event.currentTarget),
             listHeader = $this.parents('.list-header');
@@ -105,7 +98,7 @@ Template.addlistForm.events({
     }
 });
 
-Template.listActionPop.events({
+Template.listActionPopup.events({
     'click .js-close-list': function(event, t) {
         Lists.update(this._id, {
             $set: {
@@ -113,8 +106,7 @@ Template.listActionPop.events({
             }
         });
 
-        // close pop
-        Utils.Pop.close();
+        Popup.close();
 
         event.preventDefault();
     },

--- a/client/views/lists/templates.html
+++ b/client/views/lists/templates.html
@@ -2,7 +2,7 @@
     <div class="board-canvas">
         <div id="board" class="lists fancy-scrollbar js-no-higher-edits js-list-sortable ui-sortable">
             {{# each board.lists }}
-                <div class="list" popoffset='list'>
+                <div class="list">
                     <div class="list-header js-list-header non-empty clearfix {{# if currentUser.isBoardMember }}editable{{/ if }}">
                         <h2 class="list-header-name js-list-name current {{# if currentUser.isBoardMember }}hide-on-edit{{/ if }}">{{ title }}</h2>
                         {{ > listTitleEditForm list=this }}
@@ -45,7 +45,7 @@
     {{/ if }}
 </template>
 
-<template name="listActionPop">
+<template name="listActionPopup">
     <ul class="pop-over-list">
         <li><a class="js-add-card" href="#">{{_ 'add-card'}}</a></li>
         <li><a class="highlight-icon js-list-subscribe" href="#">{{_ 'subscribe'}}</a></li>

--- a/client/views/main/events.js
+++ b/client/views/main/events.js
@@ -1,9 +1,3 @@
-Template.pop.events({
-    'click .js-close-popover': function() {
-        Utils.Pop.close();
-    }
-});
-
 Template.editor.events({
   // Pressing Ctrl+Enter should submit the form.
   'keydown textarea': function(event, t) {

--- a/client/views/main/helpers.js
+++ b/client/views/main/helpers.js
@@ -34,11 +34,5 @@ Template.warning.helpers({
     }
 });
 
-Template.pop.helpers({
-    pop: function() {
-        return Session.get('pop');
-    }
-});
-
 // Register all Helpers
 _.each(Helpers, function(fn, name) { Blaze.registerHelper(name, fn); });

--- a/client/views/main/routers.js
+++ b/client/views/main/routers.js
@@ -50,12 +50,10 @@ Router.configure({
 
         // reset default sessions
         Session.set('error', false);
-        Session.set('pop', false);
         Session.set('warning', false);
         Session.set('widgets', true);
 
-        // all pages pop close
-        Utils.Pop.close();
+        Popup.close();
 
         // Layout template found then set render this.route options layout.
         if (!options.layoutTemplate) {

--- a/client/views/main/templates.html
+++ b/client/views/main/templates.html
@@ -19,7 +19,6 @@
 <template name="layout">
     {{ > yield "modal" }}
     <div id="surface">
-        {{# if session 'pop' }}{{ > pop }}{{/if}}
         <div id="header">
             <a class="header-btn header-logo bgnone" href="{{ pathFor route='Home' }}">
                 <span class="header-logo-default"></span>
@@ -43,7 +42,6 @@
 <template name='AuthLayout'>
     {{ > yield "modal" }}
     <div id="surface">
-        {{# if session 'pop' }}{{ > pop }}{{/if}}
         {{# unless isSandstorm }}
             <div id="header">
                 <div class="header-boards-button">
@@ -150,19 +148,21 @@
     {{/if}}
 </template>
 
-<template name="pop">
-    <div class="pop-over clearfix {{# unless pop.label }}miniprofile{{/ unless }}" style="display: block; left: {{ pop.left }}px; top: {{ pop.top }}px;">
+<template name="popup">
+    <div class="pop-over clearfix {{# unless title}}miniprofile{{/unless}}" style="display: block; left: {{ offset.left }}px; top: {{ offset.top }}px;">
         <div class="header clearfix">
-            <a class="back-btn js-back-view" href="#" style="display: none;">
-                <span class="icon-sm icon-leftarrow"></span>
-            </a>
-            <span class="header-title">{{ pop.label }}</span>
+            {{#if hasPopupParent}}
+                <a class="back-btn js-back-view" href="#">
+                    <span class="icon-sm icon-leftarrow"></span>
+                </a>
+            {{/if}}
+            <span class="header-title">{{ title }}</span>
             <a class="close-btn js-close-popover" href="#">
                 <span class="icon-sm icon-close"></span>
             </a>
         </div>
         <div class="content clearfix fancy-scrollbar js-tab-parent" style="max-height: 549px;">
-            {{> UI.dynamic template=pop.template data=pop.data }}
+            {{> UI.dynamic template=popupName data=dataContext }}
         </div>
     </div>
 </template>

--- a/client/views/modal/events.js
+++ b/client/views/modal/events.js
@@ -4,11 +4,11 @@ Template.modal.events({
         // div itself, not a child (ie, not the overlay window)
         if (event.target !== event.currentTarget)
             return;
-        Utils.goBoardId(this.board._id);
+        Utils.goBoardId(this.card.board()._id);
         event.preventDefault();
     },
     'click .js-close-window': function(event) {
-        Utils.goBoardId(this.board._id);
+        Utils.goBoardId(this.card.board()._id);
         event.preventDefault();
     }
 });

--- a/client/views/users/events.js
+++ b/client/views/users/events.js
@@ -48,31 +48,14 @@ Template.signup.events({
 
 
 Template.memberHeader.events({
-    'click .js-open-header-member-menu': function(event, t) {
-        var user = Meteor.user(),
-            label = user.profile.name + ' ('+ user.username +')';
-
-        // open pop
-        Utils.Pop.open('memberMenuPop', label, t.firstNode);
-
-        // return false;
-        event.preventDefault();
-    },
-    'click .js-open-add-menu': function(event, t) {
-
-        // open pop
-        Utils.Pop.open('createBoardPop', 'Create Board', t.firstNode);
-
-        // return false;
-        event.preventDefault();
-    }
+    'click .js-open-header-member-menu': Popup.open('memberMenu'),
+    'click .js-open-add-menu': Popup.open('createBoard')
 });
 
-Template.memberMenuPop.events({
+Template.memberMenuPopup.events({
     'click .js-logout': function(event, t) {
         event.preventDefault();
 
-        // Logout
         Meteor.logout(function() {
             Router.go('Home');
         });
@@ -109,10 +92,5 @@ Template.profileEditForm.events({
 
 
 Template.memberName.events({
-    'click .js-show-mem-menu': function(event, t) {
-        Utils.Pop.open('userPop', false, event.currentTarget, {
-            user: this.user
-        });
-        event.preventDefault();
-    }
+    'click .js-show-mem-menu': Popup.open('user')
 });

--- a/client/views/users/templates.html
+++ b/client/views/users/templates.html
@@ -51,7 +51,7 @@
 </template>
 
 <template name="memberHeader">
-    <div class="header-user" popOffset='headerUser'>
+    <div class="header-user">
         <a class="header-btn js-open-add-menu" href="#" title="{{_ 'add-board'}}">
             <span class="header-btn-icon icon-lg icon-add light"></span>
         </a>
@@ -67,7 +67,7 @@
     </div>
 </template>
 
-<template name="memberMenuPop">
+<template name="memberMenuPopup">
     <ul class="pop-over-list">
         <li><a class="js-profile" href="{{ pathFor route='Profile' username=currentUser.username }}">{{_ 'profile'}}</a></li>
         <li><a class="js-cards" href="{{ pathFor route='Settings' }}">{{_ 'settings'}}</a></li>
@@ -159,7 +159,7 @@
     {{ /if }}
 </template>
 
-<template name="userPop">
+<template name="userPopup">
     <div class="board-member-menu">
         <div class="mini-profile-info">
             <div class="member-large">
@@ -177,7 +177,7 @@
 
 
 <template name="memberName">
-    <a class="inline-object js-show-mem-menu" href="{{ pathFor route='Profile' username=user.username }}" popoffset='{{ offset }}'>
+    <a class="inline-object js-show-mem-menu" href="{{ pathFor route='Profile' username=user.username }}">
         {{ user.profile.name }}
         {{# if username }}
             ({{ user.username }})
@@ -186,7 +186,7 @@
 </template>
 
 <template name="avatar">
-    <div class="member {{# if draggable }}js-member{{else}}js-member-on-card-menu{{/ if}}" popOffset='{{ popOffset }}'>
+    <div class="member {{# if draggable }}js-member{{else}}js-member-on-card-menu{{/ if}}">
         <span class="member-initials" title="{{ user.profile.name }} ({{ user.username }})">
             {{ firstChar user.profile.name }}
         </span>

--- a/client/views/widgets/helpers.js
+++ b/client/views/widgets/helpers.js
@@ -1,15 +1,24 @@
-Template.addMemberPop.helpers({
+Template.addMemberPopup.helpers({
     isBoardMember: function() {
         var user = Users.findOne(this._id);
         return user && user.isBoardMember();
     }
 });
 
-Template.memberPop.helpers({
+Template.memberPopup.helpers({
     user: function() {
         return Users.findOne(this.memberId)
     },
     memberType: function() {
         return Users.findOne(this.memberId).isBoardAdmin() ? 'admin' : 'normal';
+    }
+});
+
+Template.removeMemberPopup.helpers({
+    user: function() {
+        return Users.findOne(this.memberId)
+    },
+    board: function() {
+        return Boards.findOne(Router.current().params.boardId);
     }
 });

--- a/client/views/widgets/rendered.js
+++ b/client/views/widgets/rendered.js
@@ -13,7 +13,7 @@ Template.membersWidget.rendered = function() {
     }
 };
 
-Template.addMemberPop.rendered = function() {
+Template.addMemberPopup.rendered = function() {
     // Input autofocus
     this.find('.search-with-spinner input').focus();
 

--- a/client/views/widgets/templates.html
+++ b/client/views/widgets/templates.html
@@ -42,7 +42,7 @@
             {{# unless isSandstorm }}
                 {{# if currentUser.isBoardAdmin }}
                     <li>
-                        <a class="nav-list-item nav-list-sub-item js-close-board" href="#" popOffset='boardRemove'>{{_ 'close-board'}}</a>
+                        <a class="nav-list-item nav-list-sub-item js-close-board" href="#">{{_ 'close-board'}}</a>
                     </li>
                 {{/ if }}
             {{/ unless }}
@@ -59,11 +59,11 @@
         <div class="board-widget-content">
             <div class="board-widget-members js-list-board-members clearfix js-list-draggable-board-members">
                 {{# each board.members }}
-                    {{> avatar draggable=true memberId=this.userId popOffset='member' }}
+                    {{> avatar draggable=true memberId=this.userId }}
                 {{/ each }}
             </div>
             {{# if currentUser.isBoardAdmin }}
-                <a href="#" class="button-link js-open-manage-board-members" popOffset='membersAdd'>
+                <a href="#" class="button-link js-open-manage-board-members">
                     <span class="icon-sm icon-member"></span> {{_ 'add-members'}}
                 </a>
             {{/ if }}
@@ -89,7 +89,7 @@
     {{/if}}
 </template>
 
-<template name='memberPop'>
+<template name='memberPopup'>
     <div class="board-member-menu">
         <div class="mini-profile-info">
             <div class="member-large">
@@ -114,7 +114,7 @@
 
                 <li>
                     {{# if currentUser.isBoardAdmin }}
-                        <a class="js-remove-member" popoffset='removeMember'>{{_ 'remove-from-board'}}</a>
+                        <a class="js-remove-member">{{_ 'remove-from-board'}}</a>
                     {{ else }}
                         <a class="js-leave-member">{{_ 'leave-board'}}</a>
                     {{/ if }}
@@ -124,12 +124,12 @@
     </div>
 </template>
 
-<template name="closeBoardPop">
+<template name="closeBoardPopup">
     <p>{{_ 'close-board-pop'}}</p>
     <input type="submit" class="js-confirm negate full" value="{{_ 'close'}}">
 </template>
 
-<template name="removeMemberPop">
+<template name="removeMemberPopup">
     <p>{{_ 'remove-member-pop'
             name=user.profile.name
             username=user.username
@@ -137,7 +137,7 @@
     <input type="submit" class="js-confirm negate full" value="{{_ 'remove-member'}}">
 </template>
 
-<template name="addMemberPop">
+<template name="addMemberPopup">
     <div class="search-with-spinner">
         {{> esInput index="users" }}
     </div>

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -116,5 +116,17 @@
     "title": "Title",
     "user-profile-not-found": "User Profile not found.",
     "username": "Username",
-    "warning-signup": "Sign up for free"
+    "warning-signup": "Sign up for free",
+    "cardLabelsPopup-title": "Labels",
+    "cardMembersPopup-title": "Members",
+    "cardMorePopup-title": "More",
+    "cardDeletePopup-title": "Delete Card?",
+    "boardChangeTitlePopup-title": "Rename Board",
+    "boardChangePermissionPopup-title": "Change Visibility",
+    "addMemberPopup-title": "Members",
+    "closeBoardPopup-title": "Close Board?",
+    "removeMemberPopup-title": "Remove Member?",
+    "createBoardPopup-title": "Create Board",
+    "listActionPopup-title": "List Actions",
+    "editLabelPopup-title": "Change Label"
 }


### PR DESCRIPTION
* New `Popup` public API that can be used directly in Blaze event maps
* Automatically calculate the popup offset using the event target size
  and the window dimensions -- before this commit the offset was
  hardcoded in the DOM with the "offset" attribute
  #54
* Support localised (translated) popup title
* Fix a bug for the labels popup -- going back was opening the popup
  in a wrong position
* Click anywhere to close a popup
  #62
* Support sub-popups, this is completly transparent in the API, if we
  open a popup B from a popup A that will automatically generate a
  "back" button from B to A
* Change the context of data provided by iron-router