### PR TITLE
Update Dockerfile to use new meteor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grigio/meteor:1.0.2.1
+FROM grigio/meteor:1.0.3.1
 
 # Add the source of your Meteor app and build
 ADD . /app


### PR DESCRIPTION
Fixes docker builds from https://github.com/libreboard/libreboard/commit/6f8d6e3bd27fbc55c6431ee4b576ba4f586e9e30 onwards.