### PR TITLE
Lower required length of username to 3. Fixes #202.

### DIFF
--- a/client/config/accounts.js
+++ b/client/config/accounts.js
@@ -5,7 +5,7 @@ AccountsTemplates.addFields([{
   type: 'text',
   displayName: 'username',
   required: true,
-  minLength: 5
+  minLength: 3
 }, emailField, passwordField]);
 
 AccountsTemplates.configure({


### PR DESCRIPTION
Given that there are no user roles defined to support something like an admin with the ability to manage overall configuration and there is no existing mechanism to handle something like a configuration file, I figured the easiest fix here is just to lower the value.

I'm not missing updating a test somewhere am I? I didn't find an associated test suite.